### PR TITLE
fix: default values of props matches the type of the prop

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -189,7 +189,7 @@ export default {
      */
     localGeocoder: {
       type: Function,
-      default: '',
+      default: null,
       required: false,
     },
     /**

--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -234,7 +234,7 @@ export default {
      */
     render: {
       type: Function,
-      default: '',
+      default: null,
       required: false,
     },
     /**

--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -180,7 +180,7 @@ export default {
      */
     filter: {
       type: Function,
-      default: '',
+      default: null,
       required: false,
     },
     /**


### PR DESCRIPTION
Update default values for props: do not use `''` (empty string) for props of type function and use `null` instead.